### PR TITLE
[#46] Refactor: Focus on naming, before release V1.2.0 

### DIFF
--- a/src/main/java/teamguu/backend/config/openapi/OpenApiConfig.java
+++ b/src/main/java/teamguu/backend/config/openapi/OpenApiConfig.java
@@ -12,18 +12,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
-//    @Bean
-//    public OpenAPI openAPI() {
-//        Info info = new Info()
-//                .title("TeamGuu API")
-//                .version("v1.0.0")
-//                .description("for teamguu application frontend");
-//
-//        return new OpenAPI()
-//                .components(new Components())
-//                .info(info);
-//    }
-
     @Bean
     public OpenAPI openAPI() {
 
@@ -31,8 +19,8 @@ public class OpenApiConfig {
 
         Info info = new Info()
                 .title("TeamGuu API")
-                .version("v1.0.0")
-                .description("for teamguu application frontend");
+                .version("v1.2.0")
+                .description("for frontend");
 
         return new OpenAPI()
                 .addSecurityItem(new SecurityRequirement()

--- a/src/main/java/teamguu/backend/domain/matchinginfo/controller/MatchingInfoController.java
+++ b/src/main/java/teamguu/backend/domain/matchinginfo/controller/MatchingInfoController.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import teamguu.backend.domain.matchinginfo.dto.CreateMatchingInfoRequestDto;
 import teamguu.backend.domain.matchinginfo.service.MatchingInfoService;
@@ -15,6 +14,7 @@ import teamguu.backend.response.Response;
 
 import javax.validation.Valid;
 
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 import static teamguu.backend.response.Response.success;
 import static teamguu.backend.response.SuccessMessage.*;
@@ -30,14 +30,14 @@ public class MatchingInfoController {
     private final TeamService teamService;
 
     @Operation(summary = "Create match API", description = "put your match info to create")
-    @ResponseStatus(OK)
+    @ResponseStatus(CREATED)
     @PostMapping()
     public Response createMatchingInfo(@Valid @RequestBody CreateMatchingInfoRequestDto createMatchingInfoRequestDto, Long teamId) {
         matchingInfoService.createMatchingInfo(createMatchingInfoRequestDto, teamService.findTeam(teamId));
         return success(SUCCESS_TO_CREATE_MATCH);
     }
 
-    @Operation(summary = "Get simple match info list API", description = "just send request")
+    @Operation(summary = "Get simple match info list API", description = "put page info what you want")
     @ResponseStatus(OK)
     @GetMapping("/simple")
     @PageableAsQueryParam

--- a/src/main/java/teamguu/backend/domain/matchinginfo/dto/MatchingInfoResponseDto.java
+++ b/src/main/java/teamguu/backend/domain/matchinginfo/dto/MatchingInfoResponseDto.java
@@ -1,13 +1,11 @@
 package teamguu.backend.domain.matchinginfo.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import teamguu.backend.domain.matchinginfo.entity.MatchingInfo;
-import teamguu.backend.domain.member.entity.Member;
 import teamguu.backend.domain.team.dto.TeamInfoResponseDto;
 
 @Data
@@ -17,17 +15,11 @@ import teamguu.backend.domain.team.dto.TeamInfoResponseDto;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MatchingInfoResponseDto {
 
-    @Schema(description = "매칭 공고문 ID")
     private Long id;
-    @Schema(description = "팀 정보")
     private TeamInfoResponseDto teamInfo;
-    @Schema(description = "매칭 희망 일시")
     private String date;
-    @Schema(description = "매칭 희망 장소")
     private String place;
-    @Schema(description = "매칭 공고문 제목")
     private String title;
-    @Schema(description = "매칭 공고문 내용")
     private String content;
 
     public static MatchingInfoResponseDto from(MatchingInfo matchingInfo) {

--- a/src/main/java/teamguu/backend/domain/matchinginfo/dto/SimpleMatchingInfoResponseDto.java
+++ b/src/main/java/teamguu/backend/domain/matchinginfo/dto/SimpleMatchingInfoResponseDto.java
@@ -17,17 +17,11 @@ import teamguu.backend.domain.team.entity.Team;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SimpleMatchingInfoResponseDto {
 
-    @Schema(description = "매칭 공고문 ID")
     private Long id;
-    @Schema(description = "간단한 팀 정보")
     private SimpleTeamInfoResponseDto simpleTeamInfo;
-    @Schema(description = "매칭 희망 지역")
     private String place;
-    @Schema(description = "매칭 희망 일시")
     private String date;
-    @Schema(description = "매칭 공고 제목")
     private String title;
-    @Schema(description = "매칭 공고 상태")
     private String status;
 
     public static SimpleMatchingInfoResponseDto from(MatchingInfo matchingInfo) {

--- a/src/main/java/teamguu/backend/domain/matchinginfo/entity/MatchingInfo.java
+++ b/src/main/java/teamguu/backend/domain/matchinginfo/entity/MatchingInfo.java
@@ -24,7 +24,7 @@ public class MatchingInfo extends EntityDateInfo {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
-
+    // TODO 생각해보니 MatchingInfo 에 sports 컬럼이 있을 필요가 있나?! team 으로 알 수 있지 않나?
     @Enumerated(EnumType.STRING)
     private Sports sports;
     private String place;

--- a/src/main/java/teamguu/backend/domain/member/controller/AuthController.java
+++ b/src/main/java/teamguu/backend/domain/member/controller/AuthController.java
@@ -65,7 +65,7 @@ public class AuthController {
     }
 
     @Operation(summary = "Reissue API", description = "put your token info which including access token and refresh token.")
-    @ResponseStatus(OK)
+    @ResponseStatus(CREATED)
     @PostMapping("/reissue")
     public Response reissue(@RequestBody TokenRequestDto tokenRequestDto) {
         return success(SUCCESS_TO_REISSUE, authService.reissue(tokenRequestDto));

--- a/src/main/java/teamguu/backend/domain/member/dto/member/GetMemberInfoResponseDto.java
+++ b/src/main/java/teamguu/backend/domain/member/dto/member/GetMemberInfoResponseDto.java
@@ -9,17 +9,11 @@ import teamguu.backend.domain.member.entity.Member;
 @Builder
 @Data
 public class GetMemberInfoResponseDto {
-    @Schema(description = "멤버 ID")
     private Long id;
-    @Schema(description = "멤버 이메일")
     private String username;
-    @Schema(description = "멤버 이름")
     private String name;
-    @Schema(description = "멤버 전화번호")
     private String phone;
-    @Schema(description = "멤버 생년월일")
     private String birth;
-    @Schema(description = "멤버 프로필 이미지 URL")
     private String profileImageUrl;
 
     public static GetMemberInfoResponseDto toDto(Member member) {

--- a/src/main/java/teamguu/backend/domain/member/dto/sign/TokenRequestDto.java
+++ b/src/main/java/teamguu/backend/domain/member/dto/sign/TokenRequestDto.java
@@ -1,5 +1,6 @@
 package teamguu.backend.domain.member.dto.sign;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class TokenRequestDto {
 
+    @Schema(description = "엑세스 토큰")
     private String accessToken;
+    @Schema(description = "리프레쉬 토큰")
     private String refreshToken;
 }

--- a/src/main/java/teamguu/backend/domain/member/service/MemberService.java
+++ b/src/main/java/teamguu/backend/domain/member/service/MemberService.java
@@ -23,7 +23,6 @@ public class MemberService {
     private final RedisService redisService;
     private final AmazonS3Service amazonS3Service;
 
-
     public GetMemberInfoResponseDto getCurrentMemberInfo() {
         return GetMemberInfoResponseDto.toDto(getCurrentMember());
     }


### PR DESCRIPTION
아 제가 이런 얘기를 들었습니다
이것도 컨벤션이긴 한데 이건 약간 국룰처럼 쓰인다고 해요
우리는 무언가를 찾는 메소드를 만들 때 보통 find**() 혹은 get**()로 네이밍을 합니다
find 혹은 get으로 네이밍을 결정하는 기준을 _**"null 처리까지 끝내고 리턴하냐 안하냐"**_ 로 하더라고요
얘를 들어 레포지토리에서 Optional로 꺼내는 메소드는 find가 되는 것이고 find 메소드를 호출해서 null 처리를 하고 리턴하는 메소드는 get이 되는 것이죠


두번째 잡지식 입니다
현재 우리는 커스텀 리스폰스의 양식을 다음과 같이 정했습니다
 ```
    private Boolean isSuccess;
    private int code;
    private String message;
    private Object result;
```
이것도 컨벤션이지만 선뱃님들 왈, 보통 code와 result만 있어도 되더라 라고 하더라고요
이제 여기서 code는 각 상황별로 세분화 하게 됩니다
예를 들어 내 팀 정보를 가져올 때, 내가 이미 팀을 만들어놔서 팀 정보가 있는 경우와 팀을 만들지 않아 빈 리스트를 가져오는 경우 두개가 있다면 하나는 2001, 하나는 2002 이런식으로 커스텀하고 코드 별 상황을 프론트와 공유하는 것이죠
이렇게 code랑 result만 있다면 응답 메시지가 조금 더 간결해진다는 장점이 있게됩니다
하지만 현재 우리 팀 상황 상  프론트와 그런 이야기를 하는게 쉽진 않겠죠
다음부터 한번 code와 result로만 응답을 커스텀해보는걸 추천해봅니다